### PR TITLE
Started frontends for workouts and challenges

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "evolve_app",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://www.laurikatajisto.com/evolve/",
+  "homepage": "http://kajlax.mbnet.fi/Projects/EvolveApp/",
   "dependencies": {
     "axios": "^0.18.0",
     "react": "^16.4.1",

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -1,13 +1,17 @@
 import React from "react";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import Workouts from "./components/Workouts/Workouts";
+import Challenges from "./components/Challenges/Challenges";
 import Frontpage from "./components/Frontpage";
 import About from "./components/About";
 
 export default class Routes extends React.PureComponent {
   render() {
     return (
-      <Router basename="/evolve"> 
+      <Router>
         <Switch>
+          <Route path="/Workouts/Workouts" component={Workouts} exact />
+          <Route path="/Challenges/Challenges" component={Challenges} exact />
           <Route path="/" component={Frontpage} exact />
           <Route path="/About" component={About} exact />
         </Switch>

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -13,10 +13,18 @@ export default class About extends React.PureComponent {
         gym training.
         <br />
         <Header color="teal" as="h3">
+          Workouts and challenges
+        </Header>
+        Head out to the workout section and choose a pre-made, approved workout.
+        When you're ready test your strength and endurance with the challenges
+        section.
+        <br />
+        <Header color="teal" as="h3">
           Evolve: Generate
         </Header>
-        Evolve: Generate is the first component of the Evolve App and generates
-        workouts by the users chosen preferences.
+        Evolve: Generate creates quickly a workout by chosen preferences. Choose
+        your workout preferences from the filters pane and click generate. Never
+        run out of ideas.
         <br />
         <Header color="teal" as="h3">
           Creators

--- a/src/components/Challenges/Challenges.js
+++ b/src/components/Challenges/Challenges.js
@@ -1,0 +1,54 @@
+import React from "react";
+import { connectContext } from "react-connect-context";
+import { Context } from "../../context";
+import Layout from "../Layout";
+import { Header, Input, Grid, Table } from "semantic-ui-react";
+
+class Challenges extends React.PureComponent {
+  render() {
+    return (
+      <Layout {...this.props}>
+        <Input
+          size="small"
+          icon="search"
+          placeholder="Search challenges..."
+          fluid
+        />
+        <br />
+        <Grid columns={3} divided stackable>
+          <Grid.Column>
+            <Header
+              as="h3"
+              content="Pirkkola challenge"
+              subheader="Kaj Laxström"
+              dividing
+              textAlign="center"
+            />
+            <Table color="pink" inverted unstackable="true">
+              <Table.Body>
+                <Table.Row>
+                  <Table.Cell>Muscle up</Table.Cell>
+                  <Table.Cell>5</Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                  <Table.Cell>Straight bar dip</Table.Cell>
+                  <Table.Cell>10</Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                  <Table.Cell>Pull up</Table.Cell>
+                  <Table.Cell>10</Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                  <Table.Cell>Push up</Table.Cell>
+                  <Table.Cell>10</Table.Cell>
+                </Table.Row>
+              </Table.Body>
+            </Table>
+          </Grid.Column>
+        </Grid>
+      </Layout>
+    );
+  }
+}
+
+export default connectContext(Context)(Challenges);

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -4,6 +4,14 @@ import { Link } from "react-router-dom";
 
 const dropdownItems = [
   {
+    Title: "Workouts",
+    Path: "/Workouts/Workouts"
+  },
+  {
+    Title: "Challenges",
+    Path: "/Challenges/Challenges"
+  },
+  {
     Title: "Evolve: Generate",
     Path: "/"
   },

--- a/src/components/Workouts/WorkoutFilters.js
+++ b/src/components/Workouts/WorkoutFilters.js
@@ -1,0 +1,55 @@
+import React, { Component } from "react";
+import { Button } from "semantic-ui-react";
+import { connectContext } from "react-connect-context";
+import { Context } from "../../context";
+
+class Filters extends Component {
+  toggleButton = value => {
+    this.props.updateFilters(value);
+  };
+
+  checkActive = value => {
+    const { filters } = this.props;
+    return filters.indexOf(value) > -1;
+  };
+
+  renderButton = text => {
+    return (
+      <Button
+        active={this.checkActive(text)}
+        onClick={() => this.toggleButton(text)}
+        content={text}
+      />
+    );
+  };
+
+  render() {
+    return (
+      <div>
+        <br />
+        <Button.Group widths="3" size="small">
+          {this.renderButton("Calisthenics")}
+          {this.renderButton("Gym")}
+          {this.renderButton("Mixed")}
+        </Button.Group>
+        <br /> <br />
+        <Button.Group widths="4" size="small">
+          {this.renderButton("Upper body")}
+          {this.renderButton("Lower body")}
+          {this.renderButton("Full body")}
+          {this.renderButton("Core")}
+        </Button.Group>
+        <br /> <br />
+        <Button.Group widths="3" size="small">
+          {this.renderButton("Beginner")}
+          {this.renderButton("Intermediate")}
+          {this.renderButton("Advanced")}
+        </Button.Group>
+        <br />
+        <br />
+      </div>
+    );
+  }
+}
+
+export default connectContext(Context)(Filters);

--- a/src/components/Workouts/Workouts.js
+++ b/src/components/Workouts/Workouts.js
@@ -1,0 +1,84 @@
+import React from "react";
+import { connectContext } from "react-connect-context";
+import { Context } from "../../context";
+import Layout from "../Layout";
+import Filters from "./WorkoutFilters";
+import { Button, Grid, Header, Table } from "semantic-ui-react";
+import { CSSTransitionGroup } from "react-transition-group";
+import "../Animations.css";
+
+class Workouts extends React.PureComponent {
+  constructor() {
+    super();
+    this.state = {
+      hideFilters: true,
+      filterIcon: "caret down"
+    };
+  }
+
+  toggleFilters = () => {
+    const { hideFilters, filterIcon } = this.state;
+    const icon = filterIcon === "caret up" ? "caret down" : "caret up";
+
+    this.setState({
+      hideFilters: !hideFilters,
+      filterIcon: icon
+    });
+  };
+
+  render() {
+    const { hideFilters, filterIcon } = this.state;
+    return (
+      <Layout {...this.props}>
+        <Button
+          content="Filters"
+          icon={filterIcon}
+          labelPosition="right"
+          color="teal"
+          size="small"
+          onClick={this.toggleFilters}
+        />
+
+        <Button content="Search" color="pink" size="small" />
+        <br />
+        <CSSTransitionGroup
+          transitionName="example"
+          transitionEnterTimeout={200}
+          transitionLeaveTimeout={200}
+        >
+          {!hideFilters ? <Filters /> : null}
+        </CSSTransitionGroup>
+        <br />
+        <Grid columns={3} divided stackable>
+          <Grid.Column>
+            <Header
+              as="h3"
+              content="Goddamn electric"
+              subheader="Mika Laaksonen"
+              dividing
+              textAlign="center"
+            />
+            <Table color="purple" inverted unstackable="true">
+              <Table.Body>
+                <Table.Row>
+                  <Table.Cell>Dip</Table.Cell>
+                  <Table.Cell>10</Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                  <Table.Cell>Pull up</Table.Cell>
+                  <Table.Cell>10</Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                  <Table.Cell>Push up</Table.Cell>
+                  <Table.Cell>10</Table.Cell>
+                </Table.Row>
+              </Table.Body>
+            </Table>
+          </Grid.Column>
+        </Grid>
+      </Layout>
+    );
+  }
+}
+
+export default connectContext(Context)(Workouts);


### PR DESCRIPTION
Notice the new subfolder structure for different app sections. The Generate-component should be also moved to Generate-folder.
And renamed to Generate. Then we could create a cool frontpage. Just a static, cool looking start page with the same top menu. Probably just a big Evolve App -logo.

- Created Workouts-page
- Created Challenges-page
- Tweaked About-page.